### PR TITLE
# aba73348 - Issue

### DIFF
--- a/src/app/components/user-list/user-list.component.ts
+++ b/src/app/components/user-list/user-list.component.ts
@@ -32,17 +32,32 @@ import { ConfirmationDialog } from '../dialogs/confirmation-dialog/confirmation-
 })
 export class UserListComponent implements OnInit, OnChanges {
 
-  @Input() users: User[] = [];
+  users: User[] = [];
+
+  // Context variables
   currentRole? : string | null = null;
+
+  // Table data source
   dataSource = new MatTableDataSource<User>();
   displayedColumns: string[] = ['user_id', 'email', 'phone_number', 'roles', 'bounded_to', 'created_at', 'status', 'actions'];
 
+  /**
+   * Constructor
+   * @param credService used to know the role of the current user
+   * @param userService used to update and delete users
+   * @param dialog      used to manage dialog references
+   */
   constructor(private credService: CredentialService, private userService : UserService, private dialog: MatDialog) {
     this.currentRole = this.credService.getUser()?.roles;
   }
 
   ngOnInit(): void {
-    this.dataSource.data = this.users;  // Inicializa la data source con los usuarios
+    this.userService.getUsers().subscribe({
+      next: (data: User[]) => {
+        this.users = data;
+        this.dataSource.data = this.users;
+      }
+    })
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -67,6 +82,15 @@ export class UserListComponent implements OnInit, OnChanges {
   changeStatus(user: User): void {
     const newStatus = user.status === "active" ? "blocked":"active";
     console.log('Change status', user);
+  }
+
+  /**
+   * Add new user
+   * @param newUser 
+   */
+  addUserToList(newUser: User): void {
+    this.users.push(newUser);
+    this.dataSource.data = this.users; 
   }
 
   /**

--- a/src/app/feature/administracion/usuarios/usuarios.component.html
+++ b/src/app/feature/administracion/usuarios/usuarios.component.html
@@ -18,7 +18,7 @@
   </div>
 
   <div right>
-    <user-list [users]="users"></user-list>
+    <user-list></user-list>
   </div>
 
 </main-layout>

--- a/src/app/feature/administracion/usuarios/usuarios.component.ts
+++ b/src/app/feature/administracion/usuarios/usuarios.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectorRef, ViewChild } from '@angular/core';
 
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import {MatIconModule} from '@angular/material/icon';
@@ -21,16 +21,12 @@ import { UserAddComponent } from '../../../components/user-add/user-add.componen
   styleUrls: ['./usuarios.component.css']
 })
 export class UsuariosComponent {
-  users: User[] = []
+
+  @ViewChild(UserListComponent) userListComponent!: UserListComponent;
 
   constructor(private userService: UserService, private dialog: MatDialog, private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {
-    this.userService.getUsers().subscribe({
-      next: (data: User[]) => {
-        this.users = data;
-      }
-    });
   }
 
   openDialog(action: string): void {
@@ -58,7 +54,7 @@ export class UsuariosComponent {
         if (user) {
           this.userService.postNewUser(user).subscribe({
             next : (newUser) => {
-              this.users = [...this.users, newUser];
+              this.userListComponent.addUserToList(newUser);
             },
             error: (err) => {
               alert("There were an error creating the user. Please contact to your administrator.");


### PR DESCRIPTION
## Current Scenario:

GIVEN un usuario ADM que ingresan a Polaris Admin Web app, AND navega sobre menu: Administración/Usuarios
WHEN un usuario es eliminado
AND un nuevo usuario es agregado
THEN la tabla de lista de usuarios visualiza aún al usuario eliminado

## Expected behaiviour:

THEN la tabla de lista de usuarios visualiza solo a los usuarios existentes en la base de datos

## Solution:

- Usuarios.component: has not functionality to show users and only advice user-list when there are changes
- user-list: manage the read of users from db and expose a function to reload the list of users